### PR TITLE
feat: Set CMake minimum required C++ version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,4 +5,6 @@ project(one-chart
         HOMEPAGE_URL "https://github.com/The-Three-Dudes/one-chart"
         LANGUAGES CXX C)
 
+set(CMAKE_CXX_STANDARD 11)
+
 add_executable(one-chart main.cpp)


### PR DESCRIPTION
# Description

For now, we set C++ minimum required version to 11 in preparation for integrating doctest. When a higher level C++ version is required we will increment then.

Closes #38 

# Checklist

- [x] Relevant issue linked.
- [x] No other open pull requests for the same issue?
- [x] This pull request targets develop and not main.
- [x] Does your branch follow our Git Flow strategy?
- [x] You have only one commit? If not squash into one.
- [x] Does commit message follow conventional commit strategy?
