### PR TITLE
feat(test): Add doctest testing library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,4 +7,48 @@ project(one-chart
 
 set(CMAKE_CXX_STANDARD 11)
 
+include(FetchContent)
+
+FetchContent_Declare(
+        doctest
+        GIT_REPOSITORY https://github.com/doctest/doctest.git
+        GIT_TAG      b7c21ec5ceeadb4951b00396fc1e4642dd347e5f
+        #https://github.com/doctest/doctest/releases/download/v2.4.9/doctest.h
+)
+
+FetchContent_MakeAvailable(doctest)
+
 add_executable(one-chart main.cpp)
+
+target_link_libraries(one-chart doctest)
+
+set(ENABLE_TESTING ON CACHE ON "Enable testing" FORCE)
+
+set(DOCTEST_CONFIG_DISABLE ON)
+if(ENABLE_TESTING)
+    include(CTest)
+    set(DOCTEST_CONFIG_DISABLE OFF)
+    include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
+    doctest_discover_tests(one-chart)
+endif()
+configure_file("${CMAKE_SOURCE_DIR}/include/doctest_proxy.h.in" "${CMAKE_SOURCE_DIR}/include/doctest_proxy.h")
+
+# create macros for development introspection
+# print all variables
+macro(print_all_variables)
+    message(STATUS "print_all_variables------------------------------------------{")
+    get_cmake_property(_variableNames VARIABLES)
+    foreach (_variableName ${_variableNames})
+        message(STATUS "${_variableName}=${${_variableName}}")
+    endforeach()
+    message(STATUS "print_all_variables------------------------------------------}")
+endmacro()
+# print target libraries
+macro(print_target_libraries)
+    message(STATUS "print_target_libraries---------------------------------------{")
+    get_target_property(OUT ${PROJECT_NAME} LINK_LIBRARIES)
+    message(STATUS ${OUT})
+    message(STATUS "print_target_libraries---------------------------------------}")
+endmacro()
+
+#print_all_variables()

--- a/include/doctest_proxy.h
+++ b/include/doctest_proxy.h
@@ -1,0 +1,8 @@
+#ifndef ONE_CHART_DOCTEST_PROXY_H
+#define ONE_CHART_DOCTEST_PROXY_H
+
+#define DOCTEST_CONFIG_IMPLEMENT
+/* #undef DOCTEST_CONFIG_DISABLE */
+#include "doctest/doctest.h"
+
+#endif //ONE_CHART_DOCTEST_PROXY_H

--- a/include/doctest_proxy.h.in
+++ b/include/doctest_proxy.h.in
@@ -1,0 +1,8 @@
+#ifndef ONE_CHART_DOCTEST_PROXY_H
+#define ONE_CHART_DOCTEST_PROXY_H
+
+#define DOCTEST_CONFIG_IMPLEMENT
+#cmakedefine DOCTEST_CONFIG_DISABLE
+#include "doctest/doctest.h"
+
+#endif //ONE_CHART_DOCTEST_PROXY_H

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,30 @@
 #include <iostream>
+#include "include/doctest_proxy.h"
 
 int main(int argc, char **argv) {
+	doctest::Context context;
+
+	// !!! THIS IS JUST AN EXAMPLE SHOWING HOW DEFAULTS/OVERRIDES ARE SET !!!
+
+	// defaults
+	context.addFilter("test-case-exclude", "*math*"); // exclude test cases with "math" in their name
+	context.setOption("abort-after", 5);              // stop test execution after 5 failed assertions
+	context.setOption("order-by", "name");            // sort the test cases by their name
+
+	context.applyCommandLine(argc, argv);
+
+	// overrides
+	context.setOption("no-breaks", true);             // don't break in the debugger when assertions fail
+
+	int res = context.run(); // run
+
+	if(context.shouldExit()) // important - query flags (and --exit) rely on the user doing this
+		return res;          // propagate the result of the tests
+
+	int client_stuff_return_code = 0;
+	// your program - if the testing framework is integrated in your production code
 	std::cout << "Hello, World!" << std::endl;
+	client_stuff_return_code = 0;
+
+	return res + client_stuff_return_code; // the result from doctest is propagated here as well
 }


### PR DESCRIPTION
# Description

Add the doctest framework using CMake's FetchContent capabilities. Also, setup a macro to be able to enable doctest and CTest from CMake's configuration.

Closes #26

#Checklist
- [x] Relevant issue linked.
- [x] No other open pull requests for the same issue?
- [x] This pull request targets develop and not main.
- [x] Does your branch follow our Git Flow strategy?
- [x] You have only one commit? If not squash into one.
- [x] Does commit message follow conventional commit strategy?
- [ ] Have you added corresponding changes to documentation?
- [x] Have you introduced new dependencies?