### PR TITLE
feat: Get GLFW using CMake

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install dependency packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y xorg-dev
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 project(one-chart
-        VERSION 0.0.2
+        VERSION 0.0.3
         DESCRIPTION ""
         HOMEPAGE_URL "https://github.com/The-Three-Dudes/one-chart"
         LANGUAGES CXX C)
@@ -12,15 +12,26 @@ include(FetchContent)
 FetchContent_Declare(
         doctest
         GIT_REPOSITORY https://github.com/doctest/doctest.git
-        GIT_TAG      b7c21ec5ceeadb4951b00396fc1e4642dd347e5f
-        #https://github.com/doctest/doctest/releases/download/v2.4.9/doctest.h
+        GIT_TAG b7c21ec5ceeadb4951b00396fc1e4642dd347e5f
+        #https://github.com/doctest/doctest/releases/tag/v2.4.9
 )
 
-FetchContent_MakeAvailable(doctest)
+set(GLFW_BUILD_DOCS FALSE)
+set(GLFW_BUILD_EXAMPLES FALSE)
+set(GLFW_BUILD_TESTS FALSE)
+FetchContent_Declare(
+	glfw
+	GIT_REPOSITORY https://github.com/glfw/glfw.git
+	GIT_TAG 7482de6071d21db77a7236155da44c172a7f6c9e
+	#https://github.com/glfw/glfw/releases/tag/3.3.8
+)
+FetchContent_MakeAvailable(doctest glfw)
 
 add_executable(one-chart main.cpp)
 
-target_link_libraries(one-chart doctest)
+add_dependencies(${PROJECT_NAME} glfw)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE doctest glfw)
 
 set(ENABLE_TESTING ON CACHE ON "Enable testing" FORCE)
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include "include/doctest_proxy.h"
+#include "GLFW/glfw3.h"
 
 int basic_test() {
     return 4;


### PR DESCRIPTION
# Description

This commit downloads GLFW using CMake and install GLFW's dependencies onto the linux CI server.

Closes #27

# Checklist
- [x] Relevant issue linked.
- [x] No other open pull requests for the same issue?
- [x] This pull request targets develop and not main.
- [x] Does your branch follow our Git Flow strategy?
- [x] You have only one commit? If not squash into one.
- [x] Does commit message follow conventional commit strategy?
- [x] Does submission pass tests locally?
- [ ] Have you added new tests showing fix/feature works?
- [ ] Have you added corresponding changes to documentation?
- [x] Have you introduced new dependencies?
