### PR TITLE
build: Enable warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+set(OPT_WARNINGS_AS_ERRORS_DEVELOPER_DEFAULT TRUE)
+
 include(FetchContent)
 
 FetchContent_Declare(
@@ -77,7 +79,7 @@ add_dependencies(${PROJECT_NAME} glfw)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE doctest glfw IMGUI_LIB IMPLOT_LIB)
 
-set(ENABLE_TESTING ON CACHE ON "Enable testing" FORCE)
+set(ENABLE_TESTING ON CACHE BOOL "Enable testing" FORCE)
 
 set(DOCTEST_CONFIG_DISABLE ON)
 if(ENABLE_TESTING)
@@ -106,4 +108,4 @@ macro(print_target_libraries)
     message(STATUS "print_target_libraries---------------------------------------}")
 endmacro()
 
-print_all_variables()
+#print_all_variables()


### PR DESCRIPTION
# Description

Simply enables CMake to elevate warnings to the error level. It's a common best-practice and should be set early to avoid as many bugs as possible.

Closes #75

# Checklist
- [x] Relevant issue linked.
- [x] No other open pull requests for the same issue?
- [x] This pull request targets develop and not main.
- [x] Does your branch follow our Git Flow strategy?
- [x] You have only one commit? If not squash into one.
- [x] Does commit message follow conventional commit strategy?
- [x] Does submission pass tests locally?
- [ ] Have you added new tests showing fix/feature works?
- [ ] Have you added corresponding changes to documentation?
- [ ] Have you introduced new dependencies?