### PR TITLE
ci: Add clang-format to continuous integration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,140 @@
+Language:        Cpp
+AccessModifierOffset: 0
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     true
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        c++11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseTab:          Never

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,19 @@ env:
   BUILD_TYPE: Release
 
 jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: run clang-format
+      uses: jidicula/clang-format-action@v4.9.0
+      with:
+        clang-format-version: '11'
+
   build-and-test:
+    needs: clang-format
     strategy:
       fail-fast: false # prevents a failure from stopping other executions
       matrix:

--- a/include/doctest_proxy.h
+++ b/include/doctest_proxy.h
@@ -5,4 +5,4 @@
 /* #undef DOCTEST_CONFIG_DISABLE */
 #include "doctest/doctest.h"
 
-#endif //ONE_CHART_DOCTEST_PROXY_H
+#endif // ONE_CHART_DOCTEST_PROXY_H

--- a/include/doctest_proxy.h.in
+++ b/include/doctest_proxy.h.in
@@ -5,4 +5,4 @@
 #cmakedefine DOCTEST_CONFIG_DISABLE
 #include "doctest/doctest.h"
 
-#endif //ONE_CHART_DOCTEST_PROXY_H
+#endif // ONE_CHART_DOCTEST_PROXY_H

--- a/main.cpp
+++ b/main.cpp
@@ -1,41 +1,47 @@
-#include <iostream>
-#include "include/doctest_proxy.h"
 #include "GLFW/glfw3.h"
 #include "imgui.h"
 #include "imgui_impl_glfw.h"
 #include "imgui_impl_opengl3.h"
 #include "implot.h"
+#include "include/doctest_proxy.h"
+#include <iostream>
 
 int basic_test() {
     return 4;
 }
 
 int main(int argc, char **argv) {
-	doctest::Context context;
+    doctest::Context context;
 
-	// !!! THIS IS JUST AN EXAMPLE SHOWING HOW DEFAULTS/OVERRIDES ARE SET !!!
+    // !!! THIS IS JUST AN EXAMPLE SHOWING HOW DEFAULTS/OVERRIDES ARE SET !!!
 
-	// defaults
-	context.addFilter("test-case-exclude", "*math*"); // exclude test cases with "math" in their name
-	context.setOption("abort-after", 5);              // stop test execution after 5 failed assertions
-	context.setOption("order-by", "name");            // sort the test cases by their name
+    // defaults
+    context.addFilter("test-case-exclude",
+                      "*math*"); // exclude test cases with "math" in their name
+    context.setOption("abort-after",
+                      5); // stop test execution after 5 failed assertions
+    context.setOption("order-by", "name"); // sort the test cases by their name
 
-	context.applyCommandLine(argc, argv);
+    context.applyCommandLine(argc, argv);
 
-	// overrides
-	context.setOption("no-breaks", true);             // don't break in the debugger when assertions fail
+    // overrides
+    context.setOption("no-breaks",
+                      true); // don't break in the debugger when assertions fail
 
-	int res = context.run(); // run
+    int res = context.run(); // run
 
-	if(context.shouldExit()) // important - query flags (and --exit) rely on the user doing this
-		return res;          // propagate the result of the tests
+    if (context.shouldExit()) // important - query flags (and --exit) rely on
+                              // the user doing this
+        return res;           // propagate the result of the tests
 
-	int client_stuff_return_code = 0;
-	// your program - if the testing framework is integrated in your production code
-	std::cout << "Hello, World!" << std::endl;
-	client_stuff_return_code = 0;
+    int client_stuff_return_code = 0;
+    // your program - if the testing framework is integrated in your production
+    // code
+    std::cout << "Hello, World!" << std::endl;
+    client_stuff_return_code = 0;
 
-	return res + client_stuff_return_code; // the result from doctest is propagated here as well
+    return res + client_stuff_return_code; // the result from doctest is
+                                           // propagated here as well
 }
 TEST_CASE("example doctest") {
     CHECK(basic_test() == 4);


### PR DESCRIPTION
# Description

Added custom .clang-format file and added a clang-format workflow to our GitHub Actions. This workflow is set to use clang-format version 11.

Note - We're using a reasonable and custom clang-format file and it has no fallback style.

Closes #89

# Checklist
- [x] Relevant issue linked.
- [x] No other open pull requests for the same issue?
- [x] This pull request targets develop and not main.
- [x] Does your branch follow our Git Flow strategy?
- [x] You have only one commit? If not squash into one.
- [x] Does commit message follow conventional commit strategy?
- [x] Does submission pass tests locally?
- [ ] Have you added new tests showing fix/feature works?
- [x] Has code been linted locally prior to submission?
- [ ] Have you added corresponding changes to documentation?
- [ ] Have you introduced new dependencies?